### PR TITLE
Prehash by default

### DIFF
--- a/minisign/minisign.py
+++ b/minisign/minisign.py
@@ -381,7 +381,7 @@ class SecretKey:
         self,
         data: Union[bytes, BinaryIO],
         *,
-        prehash: bool = False,
+        prehash: bool = True,
         untrusted_comment: Optional[str] = None,
         trusted_comment: Optional[str] = None,
     ) -> Signature:


### PR DESCRIPTION
Non-prehashed signatures will eventually be phased out, so set the default value of the `prehash` parameter of the signature function to `True`.

This matches Minisign 0.10.